### PR TITLE
Fetch user data from auth

### DIFF
--- a/apps/webapp/src/components/app-sidebar.tsx
+++ b/apps/webapp/src/components/app-sidebar.tsx
@@ -21,11 +21,6 @@ import { ModeToggle } from "./mode-toggle";
 import { Button } from "./ui/button";
 
 const data = {
-  user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/avatars/shadcn.jpg",
-  },
   navMain: [
     {
       title: "Chats",
@@ -65,6 +60,7 @@ const data = {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const healthCheck = useQuery(api.healthCheck.get);
+  const user = useQuery(api.auth.me);
 
   return (
     <Sidebar variant="inset" {...props}>
@@ -120,7 +116,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </NavSecondary>
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        {user && (
+          <NavUser
+            user={{
+              name: user.name ?? "",
+              email: user.email ?? "",
+              avatar: user.image ?? "",
+            }}
+          />
+        )}
       </SidebarFooter>
     </Sidebar>
   );

--- a/packages/backend/convex/auth.ts
+++ b/packages/backend/convex/auth.ts
@@ -1,6 +1,17 @@
 import GitHub from "@auth/core/providers/github";
-import { convexAuth } from "@convex-dev/auth/server";
+import { convexAuth, getAuthUserId } from "@convex-dev/auth/server";
+import { query } from "./_generated/server";
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [GitHub],
+});
+
+export const me = query({
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
+      return null;
+    }
+    return await ctx.db.get(userId);
+  },
 });


### PR DESCRIPTION
## Summary
- query `me` in backend auth to fetch the current user
- use the new query in the sidebar to show authenticated user's details

## Testing
- `pnpm lint`
- `pnpm check-types` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684c614cec708322b0dbbf13b5b826cd