### PR TITLE
Implement thread creation flow

### DIFF
--- a/packages/backend/convex/chatActions.ts
+++ b/packages/backend/convex/chatActions.ts
@@ -3,9 +3,10 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 
-import { components } from "./_generated/api";
-import { action } from "./_generated/server";
+import { components, internal } from "./_generated/api";
+import { action, internalAction } from "./_generated/server";
 import agent from "./agent";
+import { DEFAULT_THREAD_TITLE } from "./chat";
 
 export const sendMessage = action({
   args: { threadId: v.optional(v.string()), prompt: v.string() },
@@ -42,5 +43,90 @@ export const deleteThread = action({
       threadId,
     });
     return null;
+  },
+});
+
+export const startThreadWithAssistant = action({
+  args: { message: v.string(), optimisticTitle: v.optional(v.string()) },
+  returns: v.object({ threadId: v.string() }),
+  handler: async (ctx, { message, optimisticTitle }) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
+      throw new Error("Not authenticated");
+    }
+
+    let result: { threadId: string; messageId: string };
+    try {
+      result = await ctx.runMutation(internal.chat.createThreadWithFirstMessage, {
+        message,
+        optimisticTitle,
+      });
+    } catch (err) {
+      console.error("Failed to create thread", err);
+      throw new Error("Could not start a new thread. Please try again.");
+    }
+
+    await ctx.scheduler.runAfter(0, internal.chat.generateAssistantReplyAndTitle, {
+      threadId: result.threadId,
+      messageId: result.messageId,
+    });
+
+    return { threadId: result.threadId };
+  },
+});
+
+export const generateAssistantReplyAndTitle = internalAction({
+  args: { threadId: v.string(), messageId: v.string() },
+  handler: async (ctx, { threadId, messageId }) => {
+    const threadDoc = await ctx.runQuery(components.agent.threads.getThread, {
+      threadId,
+    });
+    const [messageDoc] = await ctx.runQuery(components.agent.messages.getMessagesByIds, {
+      messageIds: [messageId],
+    });
+    if (!threadDoc || !messageDoc) {
+      console.warn("Thread or message missing; aborting", { threadId, messageId });
+      return;
+    }
+
+    try {
+      const { thread } = await agent.continueThread(ctx, { threadId });
+      const paginated = await agent.listMessages(ctx, {
+        threadId,
+        paginationOpts: { cursor: null, numItems: 2 },
+      });
+      const hasReply = paginated.page.some(
+        (m) => m.order === messageDoc.order && m.role === "assistant",
+      );
+      if (!hasReply) {
+        await thread.generateText({ promptMessageId: messageId });
+      }
+    } catch (err) {
+      console.error("Assistant reply generation failed", err);
+    }
+
+    try {
+      const { thread } = await agent.continueThread(ctx, { threadId });
+      const meta = await thread.getMetadata();
+      if (!meta.title || meta.title === DEFAULT_THREAD_TITLE) {
+        const titleResult = await thread.generateText(
+          {
+            prompt: `Given the following user message, generate a short descriptive chat thread title under 8 words:\n"${messageDoc.text ?? messageDoc.message?.content ?? ""}"`,
+          },
+          { storageOptions: { saveMessages: "none" } },
+        );
+        const newTitle =
+          titleResult.text?.trim().slice(0, 48) ||
+          messageDoc.text?.slice(0, 48) ||
+          DEFAULT_THREAD_TITLE;
+
+        const latestMeta = await thread.getMetadata();
+        if (!latestMeta.title || latestMeta.title === DEFAULT_THREAD_TITLE) {
+          await thread.updateMetadata({ title: newTitle });
+        }
+      }
+    } catch (err) {
+      console.error("Thread title generation failed", err);
+    }
   },
 });


### PR DESCRIPTION
## Summary
- add authenticated helper and default title to chat module
- implement `createThreadWithFirstMessage` mutation
- orchestrate assistant reply and title generation with `startThreadWithAssistant`
- generate assistant reply and title in internal action

## Testing
- `pnpm check-types` *(fails: ENETUNREACH)*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_684e385da45083229800d76521662dba