### PR TITLE
Allow per-message model selection

### DIFF
--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import {
-  getSingletonHighlighter,
-  type Highlighter,
-  type LanguageInput,
-} from "shiki";
+import { getSingletonHighlighter, type Highlighter } from "shiki";
 import nord from "shiki/themes/nord.mjs";
 
 /** Props for the Markdown component. */
@@ -19,7 +16,7 @@ export function Markdown({ children }: MarkdownProps) {
   const [highlighter, setHighlighter] = React.useState<Highlighter | null>(null);
 
   React.useEffect(() => {
-    const langs: readonly LanguageInput[] = [
+    const langs = [
       "javascript",
       "typescript",
       "jsx",
@@ -42,10 +39,10 @@ export function Markdown({ children }: MarkdownProps) {
     node?: unknown;
     inline?: boolean;
     className?: string;
-    children?: React.ReactNode[];
+    children?: React.ReactNode;
   }
 
-  const components = React.useMemo(() => {
+  const components = React.useMemo<Components>(() => {
     return {
       code({ node: _node, inline, className, children: codeChildren }: CodeProps) {
         const code = String(codeChildren ?? "").replace(/\n$/, "");

--- a/apps/webapp/src/components/ui/popover.tsx
+++ b/apps/webapp/src/components/ui/popover.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+/**
+ * Wrapper around Radix's `Popover.Root` to maintain consistent styling and
+ * behavior across the application.
+ */
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root {...props} />;
+}
+
+/** Trigger element for the popover. */
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger {...props} />;
+}
+
+/**
+ * Content container for the popover menu.
+ */
+function PopoverContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        sideOffset={4}
+        className={cn(
+          "z-50 w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as chat from "../chat.js";
 import type * as chatActions from "../chatActions.js";
 import type * as healthCheck from "../healthCheck.js";
 import type * as http from "../http.js";
+import type * as models from "../models.js";
 import type * as todos from "../todos.js";
 
 import type {
@@ -37,8 +38,9 @@ declare const fullApi: ApiFromModules<{
   chatActions: typeof chatActions;
   healthCheck: typeof healthCheck;
   http: typeof http;
+  models: typeof models;
   todos: typeof todos;
-}>;
+}>; 
 declare const fullApiWithMounts: typeof fullApi;
 
 export declare const api: FilterApi<

--- a/packages/backend/convex/agent.ts
+++ b/packages/backend/convex/agent.ts
@@ -2,13 +2,22 @@ import { Agent } from "@convex-dev/agent";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 
 import { components } from "./_generated/api";
+import { defaultModel } from "./models";
 
-const openrouter = createOpenRouter({
+/**
+ * Shared OpenRouter provider used across the backend. The API key should be
+ * configured via the `OPENROUTER_API_KEY` environment variable.
+ */
+export const openrouter = createOpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY ?? "YOUR_API_KEY",
 });
 
+/**
+ * Agent instance responsible for handling LLM interactions for the support
+ * chat. It defaults to the server's `defaultModel` configuration.
+ */
 const supportAgent = new Agent(components.agent, {
-  chat: openrouter.chat("deepseek/deepseek-r1-0528:free"),
+  chat: openrouter.chat(defaultModel),
   instructions: "You are a helpful assistant.",
 });
 

--- a/packages/backend/convex/models.ts
+++ b/packages/backend/convex/models.ts
@@ -1,0 +1,46 @@
+import { v } from "convex/values";
+
+import { query } from "./_generated/server";
+
+/**
+ * List of OpenRouter model identifiers allowed for use in the app.
+ *
+ * This whitelist is referenced both on the client and the server to ensure only
+ * approved models may be used. The array is immutable to maintain type-safety
+ * when narrowing values.
+ */
+export const allowedModels = [
+  "deepseek/deepseek-chat-v3-0324:free",
+  "deepseek/deepseek-r1-0528:free",
+  "deepseek/deepseek-r1:free",
+  "google/gemma-3-27b-it:free",
+  "google/gemini-2.0-flash-exp:free",
+  "mistralai/mistral-nemo:free",
+  "qwen/qwq-32b:free",
+  "qwen/qwen3-32b-04-28:free",
+] as const;
+
+/**
+ * The default model used when a user hasn't explicitly selected one.
+ */
+export const defaultModel = "deepseek/deepseek-r1-0528:free" as const;
+
+export type ModelConfig = {
+  defaultModel: typeof defaultModel;
+  models: readonly string[];
+};
+
+/**
+ * Query returning the server-side model configuration.
+ */
+export const listModels = query({
+  args: {} as Record<never, never>,
+  returns: v.object({
+    defaultModel: v.string(),
+    models: v.array(v.string()),
+  }),
+  handler: async () => ({
+    defaultModel,
+    models: [...allowedModels],
+  }),
+});


### PR DESCRIPTION
## Summary
- provide OpenRouter model whitelist and default on server
- expose query to fetch model list
- export openrouter provider instance
- allow selecting a model when sending a message
- add Radix popover component for model menu
- add loading state for model selection and disable send until ready
- document new modules and update type safety
- close model menu when a model is selected
- fix type safety in Markdown component and ChatView

## Testing
- `npx --no-install tsc -p packages/backend/convex/tsconfig.json --noEmit`
- `npx --no-install tsc -p apps/webapp/tsconfig.json --noEmit`
- `pnpm lint`
- `pnpm check-types` *(fails: ENETUNREACH to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_684daf427cc88322a6700204be4d0486