### PR TITLE
Handle deleted threads gracefully

### DIFF
--- a/apps/webapp/src/components/redirect-error-boundary.tsx
+++ b/apps/webapp/src/components/redirect-error-boundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ReactNode, useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+function Redirect({ to }: { to: string }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate({ to });
+  }, [navigate, to]);
+  return null;
+}
+
+export interface RedirectErrorBoundaryProps {
+  /** Path to navigate to when an error is caught. */
+  to: string;
+  children: ReactNode;
+}
+
+interface RedirectErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Simple error boundary that redirects when an error is encountered.
+ */
+export class RedirectErrorBoundary extends Component<
+  RedirectErrorBoundaryProps,
+  RedirectErrorBoundaryState
+> {
+  state: RedirectErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): RedirectErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error("Error caught in RedirectErrorBoundary:", error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <Redirect to={this.props.to} />;
+    }
+    return this.props.children;
+  }
+}

--- a/apps/webapp/src/main.tsx
+++ b/apps/webapp/src/main.tsx
@@ -12,7 +12,7 @@ const router = createRouter({
   routeTree,
   defaultPreload: "intent",
   defaultPendingComponent: () => <Loader />,
-  context: {},
+  context: { convex },
   Wrap: function WrapComponent({ children }: { children: ReactNode }) {
     return <ConvexAuthProvider client={convex}>{children}</ConvexAuthProvider>;
   },

--- a/apps/webapp/src/routes/__root.tsx
+++ b/apps/webapp/src/routes/__root.tsx
@@ -10,11 +10,17 @@ import {
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { Authenticated, AuthLoading, Unauthenticated } from "convex/react";
+import { ConvexReactClient } from "convex/react";
 
 import "../index.css";
 
-// Using Record<string, never> to represent an empty object type
-export type RouterAppContext = Record<string, never>;
+/**
+ * Router-wide context available to all routes.
+ */
+export interface RouterAppContext {
+  /** Convex client instance used for non-hook queries in route loaders. */
+  convex: ConvexReactClient;
+}
 
 export const Route = createRootRouteWithContext<RouterAppContext>()({
   component: RootComponent,

--- a/apps/webapp/src/routes/chat.$threadId.tsx
+++ b/apps/webapp/src/routes/chat.$threadId.tsx
@@ -1,11 +1,26 @@
 import { ChatView } from "@/components/ChatView";
-import { createFileRoute } from "@tanstack/react-router";
+import { RedirectErrorBoundary } from "@/components/redirect-error-boundary";
+import { api } from "@hyperwave/backend/convex/_generated/api";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/chat/$threadId")({
+  beforeLoad: async ({ params, context }) => {
+    try {
+      await context.convex.query(api.chat.getThread, {
+        threadId: params.threadId,
+      });
+    } catch {
+      throw redirect({ to: "/" });
+    }
+  },
   component: ThreadRoute,
 });
 
 function ThreadRoute() {
   const { threadId } = Route.useParams();
-  return <ChatView threadId={threadId} />;
+  return (
+    <RedirectErrorBoundary to="/">
+      <ChatView threadId={threadId} />
+    </RedirectErrorBoundary>
+  );
 }


### PR DESCRIPTION
## Summary
- provide Convex client via router context
- check thread access during routing
- redirect to index when access fails
- add `RedirectErrorBoundary` component to handle runtime errors

## Testing
- `pnpm lint`
- `pnpm dev` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684e88e93f988322adf4d953fb069adf