### PR TITLE
Add spinner to send button while streaming

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -20,7 +20,7 @@ import { api } from "@hyperwave/backend/convex/_generated/api";
 import type { ModelInfo } from "@hyperwave/backend/convex/models";
 import { useNavigate } from "@tanstack/react-router";
 import { useAction, useQuery } from "convex/react";
-import { ArrowUp, Check, MoreHorizontal, Pencil, Trash2, X } from "lucide-react";
+import { ArrowUp, Check, Loader2, MoreHorizontal, Pencil, Trash2, X } from "lucide-react";
 
 /**
  * Component that displays the header with thread title, sidebar toggle, and thread actions
@@ -502,8 +502,12 @@ export function ChatView({
                   className="rounded-full"
                   disabled={!modelsLoaded || !prompt.trim() || isStreaming}
                 >
-                  <ArrowUp className="h-4 w-4" />
-                  <span className="sr-only">Send</span>
+                  {isStreaming ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <ArrowUp className="h-4 w-4" />
+                  )}
+                  <span className="sr-only">{isStreaming ? "Sending..." : "Send"}</span>
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show a loader instead of arrow while a reply is streaming

## Testing
- `pnpm lint`
- `npx prettier apps/webapp/src/components/ChatView.tsx --check`
- `pnpm dev` *(fails: connect ECONNREFUSED 104.16.29.34:443)*

------
https://chatgpt.com/codex/tasks/task_e_6850526ba81083229d53cf7a7aed3436