### PR TITLE
Implement chat autoscroll

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -21,6 +21,7 @@ import type { ModelInfo } from "@hyperwave/backend/convex/models";
 import { useNavigate } from "@tanstack/react-router";
 import { useAction, useQuery } from "convex/react";
 import { ArrowUp, Check, MoreHorizontal, Pencil, Trash2, X } from "lucide-react";
+import { useAutoscroll } from "../hooks/use-autoscroll";
 
 /**
  * Component that displays the header with thread title, sidebar toggle, and thread actions
@@ -355,9 +356,18 @@ export function ChatView({
   const messageList: UIMessage[] = messagesQuery ? toUIMessages(messagesQuery.results ?? []) : [];
   const hasMessages = messageList.length > 0;
 
+  const messageListRef = useRef<HTMLDivElement>(null);
+  const autoScroll = useAutoscroll(messageListRef);
+
   const send = useAction(api.chatActions.sendMessage);
 
   const isStreaming = (messagesQuery as { streaming?: boolean } | undefined)?.streaming ?? false;
+
+  useEffect(() => {
+    if (autoScroll && messageListRef.current) {
+      messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
+    }
+  }, [autoScroll, messageList, isStreaming]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -382,6 +392,7 @@ export function ChatView({
         <div className="flex flex-col h-full">
           <ThreadHeader threadId={threadId} />
           <main
+            ref={messageListRef}
             className={cn(
               "flex-1 overflow-y-auto p-4",
               hasMessages ? "space-y-4" : "flex flex-col items-center justify-center",

--- a/apps/webapp/src/hooks/use-autoscroll.ts
+++ b/apps/webapp/src/hooks/use-autoscroll.ts
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+/**
+ * Manage automatic scrolling behavior for a scroll container. Autoscroll is
+ * active by default and disabled when the user scrolls up. When the user
+ * scrolls back to the bottom, autoscroll is re-enabled.
+ *
+ * @param containerRef - Ref pointing to the scrollable element.
+ * @returns Whether autoscroll is currently active.
+ */
+export function useAutoscroll(
+  containerRef: React.RefObject<HTMLElement>,
+): boolean {
+  const [active, setActive] = React.useState(true);
+
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      const atBottom =
+        Math.ceil(el.scrollTop + el.clientHeight) >= el.scrollHeight;
+      setActive(atBottom);
+    };
+
+    el.addEventListener("scroll", handleScroll);
+    handleScroll();
+    return () => {
+      el.removeEventListener("scroll", handleScroll);
+    };
+  }, [containerRef]);
+
+  return active;
+}


### PR DESCRIPTION
## Summary
- autoscroll ChatView to bottom when new messages stream in
- pause autoscroll when user scrolls up and resume when scrolled back down

## Testing
- `pnpm dev` *(fails: command exited with error)*
- `pnpm dev:webapp` *(fails: command exited with error)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*

------
https://chatgpt.com/codex/tasks/task_e_685052b4511c83228b08dc0611e5fdbe