### PR TITLE
Integrate stick-to-bottom in chat view

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -27,7 +27,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache";
 import { useMutation } from "convex/react";
 import { ArrowUp, Check, Loader2, MoreHorizontal, Pencil, Trash2, X } from "lucide-react";
-import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+import { StickToBottom } from "use-stick-to-bottom";
 
 /**
  * Component that displays the header with thread title, sidebar toggle, and thread actions
@@ -432,33 +432,39 @@ export function ChatView({
       <SidebarInset>
         <div className="flex flex-col h-full">
           <ThreadHeader threadId={threadId} />
-          <main
-            className={cn(
-              "flex-1 overflow-y-auto p-4",
-              hasMessages ? "space-y-4" : "flex flex-col items-center justify-center",
-            )}
+          <StickToBottom
+            className="flex-1 overflow-y-auto"
+            resize="smooth"
+            initial="smooth"
           >
-            {hasMessages &&
-              messageList.map((m) => (
-                <div key={m.key} className={cn("flex w-full", m.role === "user" && "justify-end")}>
-                  {m.role === "user" ? (
-                    <div className="bg-secondary text-secondary-foreground text-lg font-normal leading-[140%] tracking-[0.18px] sm:text-base sm:leading-[130%] sm:tracking-[0.16px] rounded-xl px-2 py-1 shadow max-w-[70%] min-w-[10rem] w-fit">
-                      {m.parts.map((part: UIMessage["parts"][number], index: number) => (
-                        <div key={index}>{renderPart(part)}</div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="w-full">{renderMessageParts(m.parts)}</div>
-                  )}
-                </div>
-              ))}
-            {!threadId && (
-              <>
-                <HyperwaveLogoVertical className="block sm:hidden h-18 sm:h-20 w-auto shrink-0 text-primary" />
-                <HyperwaveLogoHorizontal className="hidden sm:block h-12 sm:h-16 md:h-18 lg:h-auto w-auto shrink-0 text-primary" />
-              </>
-            )}
-          </main>
+            <StickToBottom.Content
+              className={cn(
+                "p-4",
+                hasMessages ? "space-y-4" : "flex flex-col items-center justify-center",
+              )}
+            >
+              {hasMessages &&
+                messageList.map((m) => (
+                  <div key={m.key} className={cn("flex w-full", m.role === "user" && "justify-end")}> 
+                    {m.role === "user" ? (
+                      <div className="bg-secondary text-secondary-foreground text-lg font-normal leading-[140%] tracking-[0.18px] sm:text-base sm:leading-[130%] sm:tracking-[0.16px] rounded-xl px-2 py-1 shadow max-w-[70%] min-w-[10rem] w-fit">
+                        {m.parts.map((part: UIMessage["parts"][number], index: number) => (
+                          <div key={index}>{renderPart(part)}</div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="w-full">{renderMessageParts(m.parts)}</div>
+                    )}
+                  </div>
+                ))}
+              {!threadId && (
+                <>
+                  <HyperwaveLogoVertical className="block sm:hidden h-18 sm:h-20 w-auto shrink-0 text-primary" />
+                  <HyperwaveLogoHorizontal className="hidden sm:block h-12 sm:h-16 md:h-18 lg:h-auto w-auto shrink-0 text-primary" />
+                </>
+              )}
+            </StickToBottom.Content>
+          </StickToBottom>
           <form ref={formRef} onSubmit={handleSubmit} className="px-4 pb-4 sm:px-6 sm:pb-6">
             <div className="bg-background border rounded-xl p-3 shadow-sm flex flex-col gap-3">
               <Textarea


### PR DESCRIPTION
## Summary
- replace `<main>` with `<StickToBottom>` so new messages stay anchored
- remove unused `useStickToBottomContext` import

## Testing
- `pnpm lint`
- `pnpm format:check` *(fails: import sorting aborted due to babel parsing error)*
- `pnpm test` *(fails: could not fetch pnpm latest due to ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_e_6850f4ed03b88322ba5cb73949394c7b