### PR TITLE
Improve chat UI responsiveness

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -144,7 +144,7 @@ function ThreadHeader({ threadId }: { threadId?: string }) {
   return (
     <header className="flex items-center justify-between h-14 border-b px-4 relative">
       <SidebarTrigger className="mr-2" />
-      <div className="flex max-w-lg">
+      <div className="flex max-w-full flex-1">
         {isEditing ? (
           <div className="flex items-center gap-2">
             <Input
@@ -491,12 +491,12 @@ export function ChatView({
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <div className="relative flex flex-col h-full">
+        <div className="relative flex flex-col h-full w-full max-w-screen-md mx-auto">
           <ThreadHeader threadId={threadId} />
           <main
             ref={scrollRef}
             className={cn(
-              "relative flex-1 overflow-y-auto p-4",
+              "relative flex-1 overflow-y-auto p-4 sm:px-6",
               hasMessages ? undefined : "flex flex-col items-center justify-center",
             )}
           >
@@ -504,6 +504,7 @@ export function ChatView({
               ref={contentRef}
               className={cn(
                 hasMessages ? "space-y-4" : "flex flex-col items-center justify-center",
+                "px-4 sm:px-6",
               )}
             >
               {hasMessages &&
@@ -513,7 +514,7 @@ export function ChatView({
                     className={cn("flex w-full", m.role === "user" && "justify-end")}
                   >
                     {m.role === "user" ? (
-                      <div className="bg-secondary text-secondary-foreground text-lg font-normal leading-[140%] tracking-[0.18px] sm:text-base sm:leading-[130%] sm:tracking-[0.16px] rounded-xl px-2 py-1 shadow max-w-[70%] min-w-[10rem] w-fit">
+                      <div className="bg-secondary text-secondary-foreground text-lg font-normal leading-[140%] tracking-[0.18px] sm:text-base sm:leading-[130%] sm:tracking-[0.16px] rounded-xl px-2 py-1 shadow max-w-full sm:max-w-[70%] min-w-[10rem] w-fit">
                         {m.parts.map((part: UIMessage["parts"][number], index: number) => (
                           <div key={index}>{renderPart(part)}</div>
                         ))}

--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -5,6 +5,44 @@ import remarkGfm from "remark-gfm";
 import { getSingletonHighlighter, type Highlighter } from "shiki";
 import nord from "shiki/themes/nord.mjs";
 
+/** Render HTML returned by Shiki into a <pre> element with a copy button. */
+function ShikiPre({ html, code }: { html: string; code: string }) {
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  React.useEffect(() => {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    const pre = container.firstElementChild as HTMLPreElement | null;
+    if (pre && preRef.current) {
+      // Copy attributes from the generated <pre>
+      for (const attr of pre.attributes) {
+        if (attr.name === "style") {
+          preRef.current.style.cssText = attr.value;
+        } else if (attr.name === "class") {
+          preRef.current.className = `${attr.value} relative`;
+        } else {
+          preRef.current.setAttribute(attr.name, attr.value);
+        }
+      }
+      preRef.current.innerHTML = pre.innerHTML;
+    }
+  }, [html]);
+
+  return (
+    <pre ref={preRef} className="relative">
+      <button
+        type="button"
+        className="absolute right-2 top-2 rounded bg-background/70 px-1 text-xs hover:bg-background"
+        onClick={() => {
+          void navigator.clipboard.writeText(code);
+        }}
+      >
+        Copy
+      </button>
+    </pre>
+  );
+}
+
 /** Props for the Markdown component. */
 export interface MarkdownProps {
   /** Markdown content to render. */
@@ -52,13 +90,12 @@ export function Markdown({ children }: MarkdownProps) {
           const loaded = highlighter.getLoadedLanguages();
           const langToUse = loaded.includes(lang) ? lang : "txt";
           return (
-            <div
-              dangerouslySetInnerHTML={{
-                __html: highlighter.codeToHtml(code, {
-                  lang: langToUse,
-                  theme: "nord",
-                }),
-              }}
+            <ShikiPre
+              code={code}
+              html={highlighter.codeToHtml(code, {
+                lang: langToUse,
+                theme: "nord",
+              })}
             />
           );
         }


### PR DESCRIPTION
## Summary
- render Shiki code blocks directly in a `<pre>` element
- add a copy button to code blocks
- constrain `ChatView` to a responsive max width
- adjust message container padding and bubble sizing

## Testing
- `pnpm lint`
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851047d7b488322a61c3b49498c1769