### PR TITLE
Improve code block markup and layout

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -491,7 +491,7 @@ export function ChatView({
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <div className="relative flex flex-col h-full">
+        <div className="relative flex flex-col h-full w-full max-w-screen-md mx-auto">
           <ThreadHeader threadId={threadId} />
           <main
             ref={scrollRef}

--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -51,16 +51,31 @@ export function Markdown({ children }: MarkdownProps) {
           const lang = langMatch[1];
           const loaded = highlighter.getLoadedLanguages();
           const langToUse = loaded.includes(lang) ? lang : "txt";
-          return (
-            <div
-              dangerouslySetInnerHTML={{
-                __html: highlighter.codeToHtml(code, {
-                  lang: langToUse,
-                  theme: "nord",
-                }),
-              }}
-            />
-          );
+          const html = highlighter.codeToHtml(code, {
+            lang: langToUse,
+            theme: "nord",
+          });
+          if (typeof window !== "undefined") {
+            const parsed = new DOMParser().parseFromString(html, "text/html");
+            const pre = parsed.body.querySelector("pre");
+            if (pre) {
+              const className = pre.className;
+              const style = { backgroundColor: pre.style.backgroundColor };
+              const inner = pre.innerHTML;
+              return (
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => navigator.clipboard.writeText(code)}
+                    className="absolute right-2 top-2 rounded bg-muted px-1 text-xs text-muted-foreground"
+                  >
+                    Copy
+                  </button>
+                  <pre className={className} style={style} dangerouslySetInnerHTML={{ __html: inner }} />
+                </div>
+              );
+            }
+          }
         }
         return <code className={className}>{codeChildren}</code>;
       },


### PR DESCRIPTION
## Summary
- add copy button and remove wrapper around code blocks
- keep ChatView centered with max width

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH)*
- `pnpm dev` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6851047d7b488322a61c3b49498c1769