### PR TITLE
Improve code block UI and responsive chat layout

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -504,6 +504,7 @@ export function ChatView({
               ref={contentRef}
               className={cn(
                 hasMessages ? "space-y-4" : "flex flex-col items-center justify-center",
+                "mx-auto w-full max-w-[48rem]"
               )}
             >
               {hasMessages &&
@@ -543,7 +544,7 @@ export function ChatView({
             </button>
           )}
           <form ref={formRef} onSubmit={handleSubmit} className="px-4 pb-4 sm:px-6 sm:pb-6">
-            <div className="bg-background border rounded-xl p-3 shadow-sm flex flex-col gap-3">
+            <div className="mx-auto w-full max-w-[48rem] bg-background border rounded-xl p-3 shadow-sm flex flex-col gap-3">
               <Textarea
                 ref={inputRef}
                 value={prompt}

--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -4,6 +4,7 @@ import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getSingletonHighlighter, type Highlighter } from "shiki";
 import nord from "shiki/themes/nord.mjs";
+import { Clipboard, Check } from "lucide-react";
 
 /** Props for the Markdown component. */
 export interface MarkdownProps {
@@ -42,6 +43,70 @@ export function Markdown({ children }: MarkdownProps) {
     children?: React.ReactNode;
   }
 
+  /** Button that copies the provided code to the clipboard. */
+  function CopyButton({ code }: { code: string }) {
+    const [copied, setCopied] = React.useState(false);
+    const handleCopy = React.useCallback(() => {
+      void navigator.clipboard.writeText(code).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 3000);
+      });
+    }, [code]);
+
+    return (
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="absolute right-2 top-2 text-secondary-foreground transition-colors hover:text-secondary"
+      >
+        {copied ? <Check className="h-4 w-4 text-accent" /> : <Clipboard className="h-4 w-4" />}
+        <span className="sr-only">Copy</span>
+      </button>
+    );
+  }
+
+  /**
+   * Render a Shiki-highlighted code block without an extra container.
+   */
+  function ShikiBlock({ html, code }: { html: string; code: string }) {
+    const { className, style, tabIndex, inner } = React.useMemo(() => {
+      const template = document.createElement("template");
+      template.innerHTML = html.trim();
+      const pre = template.content.querySelector("pre");
+      return {
+        className: pre?.getAttribute("class") ?? undefined,
+        style: pre?.getAttribute("style") ?? undefined,
+        tabIndex: pre?.getAttribute("tabindex") ?? undefined,
+        inner: pre?.innerHTML ?? html,
+      };
+    }, [html]);
+
+    const styleObj = React.useMemo(() => {
+      const obj: React.CSSProperties = {};
+      if (style) {
+        for (const part of style.split(";")) {
+          const [k, v] = part.split(":");
+          if (k && v) {
+            (obj as Record<string, string>)[k.trim()] = v.trim();
+          }
+        }
+      }
+      return obj;
+    }, [style]);
+
+    return (
+      <div className="relative group">
+        <pre
+          className={className}
+          style={styleObj}
+          tabIndex={tabIndex ? Number(tabIndex) : undefined}
+          dangerouslySetInnerHTML={{ __html: inner }}
+        />
+        <CopyButton code={code} />
+      </div>
+    );
+  }
+
   const components = React.useMemo<Components>(() => {
     return {
       code({ node: _node, inline, className, children: codeChildren }: CodeProps) {
@@ -52,13 +117,12 @@ export function Markdown({ children }: MarkdownProps) {
           const loaded = highlighter.getLoadedLanguages();
           const langToUse = loaded.includes(lang) ? lang : "txt";
           return (
-            <div
-              dangerouslySetInnerHTML={{
-                __html: highlighter.codeToHtml(code, {
-                  lang: langToUse,
-                  theme: "nord",
-                }),
-              }}
+            <ShikiBlock
+              html={highlighter.codeToHtml(code, {
+                lang: langToUse,
+                theme: "nord",
+              })}
+              code={code}
             />
           );
         }


### PR DESCRIPTION
## Summary
- add clipboard copy button for code blocks
- extract ShikiBlock component to remove wrapper div
- constrain chat message list and form width for responsiveness

## Testing
- `pnpm lint`
- `pnpm format:check` *(fails: import sorting aborted due to babel parsing error)*
- `pnpm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851077bce908322b74c7aaad540fea1