### PR TITLE
Implement message pagination

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -431,10 +431,27 @@ export function ChatView({
 
   const isStreaming = (messages as { streaming?: boolean } | undefined)?.streaming ?? false;
 
+  const loadMoreRef = useRef<HTMLDivElement>(null);
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } = useStickToBottom({
     resize: "smooth",
     initial: "smooth",
   });
+
+  useEffect(() => {
+    const target = loadMoreRef.current;
+    const root = scrollRef.current;
+    if (!target || !root || !messages) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && messages.status === "CanLoadMore") {
+          messages.loadMore(20);
+        }
+      },
+      { root, threshold: 0 },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [messages]);
 
   /**
    * Height of the chat form in pixels. Used to position the
@@ -514,6 +531,13 @@ export function ChatView({
                 hasMessages ? "space-y-4" : "flex flex-col items-center justify-center",
               )}
             >
+              <div ref={loadMoreRef} />
+              {messages && messages.status === "LoadingMore" && (
+                <div className="flex justify-center py-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span className="sr-only">Loading more</span>
+                </div>
+              )}
               {hasMessages &&
                 messageList.map((m) => (
                   <div


### PR DESCRIPTION
## Summary
- load more messages when the top of the chat scroll container becomes visible
- show a spinner when additional messages are loading

## Testing
- `pnpm lint`
- `pnpm check-types` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685165a586488322b6a7373e61ec6140