### PR TITLE
Add streaming cursor

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -236,7 +236,10 @@ function hasResult(value: unknown): value is { result: unknown } {
 }
 
 /** Render a single message part based on its type. */
-function renderPart(part: UIMessage["parts"][number]): React.ReactNode {
+function renderPart(
+  part: UIMessage["parts"][number],
+  showCursor?: boolean,
+): React.ReactNode {
   switch (part.type) {
     case "text": {
       // Normalise streaming glitches:
@@ -247,6 +250,12 @@ function renderPart(part: UIMessage["parts"][number]): React.ReactNode {
       //    never sees it.
       const raw = typeof part.text === "string" ? part.text : "";
       const cleaned = raw.startsWith("undefined") ? raw.slice("undefined".length) : raw;
+
+      if (showCursor) {
+        return cleaned ? (
+          <span className="with-terminal-cursor whitespace-pre-wrap">{cleaned}</span>
+        ) : null;
+      }
 
       return cleaned ? <Markdown>{cleaned}</Markdown> : null;
     }
@@ -319,14 +328,12 @@ function renderMessageParts(parts: UIMessage["parts"], showCursor?: boolean): Re
         ([part, originalIdx]) => (
           <div
             key={`${part.type}-${originalIdx}`}
-            className={cn(part.type === "text" ? "mt-2 flex items-baseline" : "mb-2")}
+            className={cn(part.type === "text" ? "mt-2" : "mb-2")}
           >
-            <span className={cn(part.type === "text" && "inline-block")}>{renderPart(part)}</span>
-            {showCursor &&
-              part.type === "text" &&
-              originalIdx === lastTextIdx && (
-                <span className="terminal-cursor" />
-              )}
+            {renderPart(
+              part,
+              showCursor && part.type === "text" && originalIdx === lastTextIdx,
+            )}
           </div>
         ),
       )}

--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -454,3 +454,22 @@ body {
   animation: terminal-cursor 1s steps(1) infinite;
   box-shadow: 0 0 4px hsl(var(--color-primary));
 }
+
+.prose-inline {
+  @apply text-base md:text-lg leading-7;
+}
+
+.with-terminal-cursor {
+  display: inline-block;
+}
+
+.with-terminal-cursor::after {
+  content: "";
+  display: inline-block;
+  width: 0.6em;
+  height: 1em;
+  margin-left: 0.1em;
+  background: hsl(var(--color-primary));
+  animation: terminal-cursor 1s steps(1) infinite;
+  box-shadow: 0 0 4px hsl(var(--color-primary));
+}


### PR DESCRIPTION
## Summary
- add pulsing terminal-style cursor when streaming
- support cursor in message render function

## Testing
- `npx tsc -p apps/webapp/tsconfig.json --noEmit`
- `pnpm lint`
- `pnpm test` *(fails: connect ENETUNREACH registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6851b8838f908322a2e7746c755db613