### PR TITLE
Use react-shiki for Markdown code blocks

### DIFF
--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { Check, Clipboard } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
+import ShikiHighlighter from "react-shiki";
 import remarkGfm from "remark-gfm";
 import { getSingletonHighlighter, type Highlighter } from "shiki";
 import nord from "shiki/themes/nord.mjs";
@@ -131,16 +132,6 @@ export function Markdown({ children }: MarkdownProps) {
     );
   }
 
-  function parseStyle(style: string): React.CSSProperties {
-    return style.split(";").reduce((acc, part) => {
-      const [prop, value] = part.split(":");
-      if (!prop || !value) return acc;
-      const camel = prop.trim().replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-      (acc as Record<string, string>)[camel] = value.trim();
-      return acc;
-    }, {} as React.CSSProperties);
-  }
-
   const components = React.useMemo<Components>(() => {
     return {
       code({ node: _node, inline, className, children: codeChildren }: CodeProps) {
@@ -150,33 +141,22 @@ export function Markdown({ children }: MarkdownProps) {
           const lang = langMatch[1];
           const loaded = highlighter.getLoadedLanguages();
           const langToUse = loaded.includes(lang) ? lang : "txt";
-          const html = highlighter.codeToHtml(code, {
-            lang: langToUse,
-            theme: "nord",
-          });
 
-          if (typeof window !== "undefined") {
-            const doc = new window.DOMParser().parseFromString(html, "text/html");
-            const pre = doc.querySelector("pre");
-            if (pre) {
-              const cls = pre.className;
-              const styleAttr = pre.getAttribute("style") ?? undefined;
-              const tabIndexAttr = pre.getAttribute("tabindex");
-              const tabIndex = tabIndexAttr ? Number(tabIndexAttr) : undefined;
-              const innerHtml = pre.innerHTML;
-              return (
-                <pre
-                  className={cn(cls, "relative")}
-                  style={styleAttr ? parseStyle(styleAttr) : undefined}
-                  tabIndex={tabIndex}
-                >
-                  <CopyButton code={code} />
-                  <code dangerouslySetInnerHTML={{ __html: innerHtml }} />
-                </pre>
-              );
-            }
-          }
-          return <div dangerouslySetInnerHTML={{ __html: html }} />;
+          return (
+            <div className="relative">
+              <CopyButton code={code} />
+              <ShikiHighlighter
+                as="div"
+                highlighter={highlighter}
+                language={langToUse}
+                theme="nord"
+                addDefaultStyles={false}
+                className="w-full overflow-x-auto"
+              >
+                {code}
+              </ShikiHighlighter>
+            </div>
+          );
         }
         return <code className={className}>{codeChildren}</code>;
       },

--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -408,8 +408,11 @@ body {
   .prose pre code {
     @apply bg-transparent p-0 wrap-normal whitespace-pre-wrap w-full;
   }
-  pre .shiki {
-    @apply p-5 bg-muted rounded-lg wrap-normal whitespace-pre-wrap w-full;
+  #shiki-container {
+    @apply p-5 bg-muted rounded-lg w-full overflow-x-auto my-2 font-mono text-sm leading-relaxed;
+  }
+  #shiki-container pre {
+    @apply bg-transparent p-0 m-0 w-full whitespace-pre-wrap;
   }
   .shiki::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## Summary
- refactor markdown code block rendering to use `react-shiki`
- style shiki container in `index.css` for full‑width scrolling

## Testing
- `pnpm lint`
- `npx prettier --check apps/webapp/src/components/markdown.tsx apps/webapp/src/index.css`


------
https://chatgpt.com/codex/tasks/task_e_685290ab10ec832296650510aedcdfac