### PR TITLE
Use react-shiki for Markdown code blocks

### DIFF
--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -114,7 +114,7 @@ export function Markdown({ children }: MarkdownProps) {
         type="button"
         onClick={handleCopy}
         className={cn(
-          "absolute top-2 right-2 rounded-xs p-1 transition-colors",
+          "absolute top-2 left-2 rounded-xs p-1 transition-colors z-10",
           copied
             ? "bg-accent text-accent-foreground"
             : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
@@ -142,7 +142,7 @@ export function Markdown({ children }: MarkdownProps) {
                 theme={nord}
                 addDefaultStyles={false}
                 as="pre"
-                className="w-full overflow-x-auto"
+                className="w-full break-words whitespace-pre-wrap overflow-x-auto"
               >
                 {code}
               </ShikiHighlighter>

--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -360,6 +360,9 @@ body {
 }
 
 @layer components {
+  .truncate {
+    max-width: "100%";
+  }
   .prose {
     @apply max-w-prose mx-auto text-base md:text-lg leading-7 px-2 sm:px-4;
   }
@@ -410,7 +413,7 @@ body {
     @apply bg-transparent p-0 wrap-normal whitespace-pre-wrap w-full;
   }
   pre .shiki {
-    @apply p-5 bg-muted rounded-lg wrap-normal whitespace-pre-wrap w-full;
+    @apply px-6 pb-6 pt-12 bg-muted rounded-lg wrap-normal whitespace-pre-wrap w-full;
   }
   .shiki::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## Summary
- replace manual Shiki highlighter with `react-shiki`
- import react-shiki styles and tweak codeblock styles for full‑width scrolling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm format:check` *(fails: Code style issues found in 21 files)*

------
https://chatgpt.com/codex/tasks/task_e_685290ab10ec832296650510aedcdfac