### PR TITLE
Add animated reasoning details component

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -54,6 +54,7 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
     "tw-animate-css": "^1.3.4",
+    "framer-motion": "^11.0.17",
     "use-stick-to-bottom": "^1.1.1",
     "vaul": "^1.1.2",
     "zod": "^3.25.63"

--- a/apps/webapp/src/components/Message.tsx
+++ b/apps/webapp/src/components/Message.tsx
@@ -1,5 +1,6 @@
-import { useState, type JSX } from "react";
+import type { JSX } from "react";
 import { Markdown } from "@/components/markdown";
+import { ReasoningDetails } from "./reasoning-details";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "@convex-dev/agent/react";
 
@@ -72,7 +73,6 @@ function renderParts(parts: UIMessage["parts"]): JSX.Element[] {
  */
 export function Message({ m }: { m: UIMessage }) {
   // Reasoning toggle
-  const [isOpen, setIsOpen] = useState(true);
   const isStreaming = m.status === "streaming";
   const hasText = m.parts.some((p) => p.type === "text");
   const reasoning = m.parts.filter((p) => p.type === "reasoning");
@@ -89,17 +89,9 @@ export function Message({ m }: { m: UIMessage }) {
       ) : m.role === "assistant" ? (
         <div className="w-full">
           {reasoning.length > 0 && (
-            <details
-              className="prose"
-              open={isOpen}
-              onToggle={(e) => setIsOpen((e.currentTarget as HTMLDetailsElement).open)}
-            >
-              <summary className="rounded-lg p-4 text-sm text-accent-foreground/80 bg-accent/100 dark:bg-accent/20 hover:opacity-85 active:opacity-75 transition-all duration-200 ease-in-out select-none cursor-pointer">
-                {isOpen ? "Hide reasoning" : "Show reasoning"}
-              </summary>
-
+            <ReasoningDetails isStreaming={isStreaming}>
               <div className="mt-1">{renderParts(reasoning)}</div>
-            </details>
+            </ReasoningDetails>
           )}
           {renderParts(others)}
         </div>

--- a/apps/webapp/src/components/reasoning-details.tsx
+++ b/apps/webapp/src/components/reasoning-details.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronRight, Lightbulb, Loader2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { cn } from "@/lib/utils";
+
+/**
+ * Props for the {@link ReasoningDetails} component.
+ */
+export interface ReasoningDetailsProps {
+  /** Whether the reasoning is still streaming. */
+  readonly isStreaming: boolean;
+  /** The reasoning content to display. */
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Animated collapsible card that displays reasoning traces from an LLM.
+ *
+ * @example
+ * ```tsx
+ * <ReasoningDetails isStreaming={true}>
+ *   <div className="mt-1">{renderParts(reasoning)}</div>
+ * </ReasoningDetails>
+ * ```
+ */
+export function ReasoningDetails({ isStreaming, children }: ReasoningDetailsProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Always keep the latest content in view when collapsed
+  useEffect(() => {
+    if (!open && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [children, open]);
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="flex flex-row items-start gap-2 pb-2">
+        <div className="flex items-center gap-2">
+          {isStreaming ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Lightbulb className="size-4" />
+          )}
+          <div className="flex flex-col">
+            <CardTitle className="text-sm">
+              {isStreaming ? "Thinking" : "Reasoning details"}
+            </CardTitle>
+            {!isStreaming && (
+              <CardDescription>Expand for details</CardDescription>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="ml-auto"
+          aria-label={open ? "Collapse" : "Expand"}
+        >
+          <motion.div
+            animate={{ rotate: open ? 90 : 0 }}
+            transition={{ type: "spring", stiffness: 300, damping: 20 }}
+          >
+            <ChevronRight className="size-4" />
+          </motion.div>
+        </button>
+      </CardHeader>
+      <AnimatePresence initial={false}>
+        <motion.div
+          key="content"
+          initial={false}
+          animate={{ height: open ? "auto" : 0 }}
+          style={{ overflow: "hidden" }}
+          transition={{ type: "tween", duration: 0.2 }}
+        >
+          <CardContent
+            ref={containerRef}
+            className={cn(
+              "relative pr-2", // extra space for scrollbar
+              !open && "max-h-[200px] overflow-y-auto"
+            )}
+          >
+            {!open && (
+              <div className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-card to-transparent" />
+            )}
+            <motion.div layout>{children}</motion.div>
+          </CardContent>
+        </motion.div>
+      </AnimatePresence>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ReasoningDetails` component to display streamed LLM reasoning
- switch `Message` to use the new component
- install `framer-motion` in the webapp

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef3ad2d88322843317051c2a3912