### PR TITLE
Add ReasoningDetails component

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -49,6 +49,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-shiki": "^0.7.1",
+    "framer-motion": "^11.0.0",
     "react-textarea-autosize": "^8.5.9",
     "shiki": "^3.6.0",
     "sonner": "^1.7.4",

--- a/apps/webapp/src/components/Message.tsx
+++ b/apps/webapp/src/components/Message.tsx
@@ -1,4 +1,5 @@
-import { useState, type JSX } from "react";
+import { type JSX } from "react";
+import { ReasoningDetails } from "./ReasoningDetails";
 import { Markdown } from "@/components/markdown";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "@convex-dev/agent/react";
@@ -71,10 +72,7 @@ function renderParts(parts: UIMessage["parts"]): JSX.Element[] {
  * Render a single message.
  */
 export function Message({ m }: { m: UIMessage }) {
-  // Reasoning toggle
-  const [isOpen, setIsOpen] = useState(true);
   const isStreaming = m.status === "streaming";
-  const hasText = m.parts.some((p) => p.type === "text");
   const reasoning = m.parts.filter((p) => p.type === "reasoning");
   const others = m.parts.filter((p) => p.type !== "reasoning");
 
@@ -89,17 +87,11 @@ export function Message({ m }: { m: UIMessage }) {
       ) : m.role === "assistant" ? (
         <div className="w-full">
           {reasoning.length > 0 && (
-            <details
-              className="prose"
-              open={isOpen}
-              onToggle={(e) => setIsOpen((e.currentTarget as HTMLDetailsElement).open)}
-            >
-              <summary className="rounded-lg p-4 text-sm text-accent-foreground/80 bg-accent/100 dark:bg-accent/20 hover:opacity-85 active:opacity-75 transition-all duration-200 ease-in-out select-none cursor-pointer">
-                {isOpen ? "Hide reasoning" : "Show reasoning"}
-              </summary>
-
-              <div className="mt-1">{renderParts(reasoning)}</div>
-            </details>
+            <div className="mb-2">
+              <ReasoningDetails isStreaming={isStreaming}>
+                <div className="prose">{renderParts(reasoning)}</div>
+              </ReasoningDetails>
+            </div>
           )}
           {renderParts(others)}
         </div>

--- a/apps/webapp/src/components/ReasoningDetails.tsx
+++ b/apps/webapp/src/components/ReasoningDetails.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardAction } from "./ui/card";
+import { Loader2, Lightbulb, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { motion } from "framer-motion";
+
+export interface ReasoningDetailsProps {
+  readonly isStreaming: boolean;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Card component that displays reasoning traces from an LLM.
+ * It can be expanded to show the full content or collapsed to a
+ * preview limited to 200px in height. Content growth while streaming
+ * is smoothly animated.
+ */
+export function ReasoningDetails({ isStreaming, children }: ReasoningDetailsProps) {
+  const [open, setOpen] = React.useState(false);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const collapsedHeight = 200;
+  const [needsFade, setNeedsFade] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const check = () => {
+      setNeedsFade(el.scrollHeight > collapsedHeight);
+    };
+    check();
+  }, [children, collapsedHeight]);
+
+  const icon = isStreaming ? (
+    <Loader2 className="size-4 animate-spin" />
+  ) : (
+    <Lightbulb className="size-4" />
+  );
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="flex flex-row items-start gap-3">
+        <div className="flex items-start gap-3 flex-1">
+          {icon}
+          <div className="flex flex-col">
+            <CardTitle className="text-sm">
+              {isStreaming ? "Thinking" : "Reasoning details"}
+            </CardTitle>
+            {!isStreaming && (
+              <CardDescription>Expand for details</CardDescription>
+            )}
+          </div>
+        </div>
+        <CardAction>
+          <button
+            type="button"
+            aria-label={open ? "Collapse" : "Expand"}
+            onClick={() => setOpen((v) => !v)}
+            className="text-muted-foreground"
+          >
+            <ChevronRight
+              className={cn(
+                "size-4 transition-transform",
+                open && "rotate-90"
+              )}
+            />
+          </button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="p-0">
+        <motion.div
+          layout
+          initial={false}
+          animate={{ height: open ? "auto" : collapsedHeight }}
+          style={{ overflow: "hidden" }}
+        >
+          <div ref={contentRef} className="relative flex flex-col justify-end px-6 py-4">
+            {children}
+            {needsFade && !open && (
+              <div className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-b from-card to-card/0" />
+            )}
+          </div>
+        </motion.div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add `<ReasoningDetails>` collapsible card to display streaming reasoning details
- show reasoning traces in `Message` using this card
- add `framer-motion` dependency

## Testing
- `pnpm lint`
- `pnpm check-types` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef3ad2d88322843317051c2a3912