### PR TITLE
Add file upload feature

### DIFF
--- a/packages/backend/convex/files.ts
+++ b/packages/backend/convex/files.ts
@@ -1,0 +1,71 @@
+import { storeFile, getFile } from "@convex-dev/agent";
+import { v } from "convex/values";
+import { requireOwnThread, requireUserId } from "../utils/threadOwnership";
+import { internal, components } from "./_generated/api";
+import { action, mutation } from "./_generated/server";
+import agent from "./agent";
+
+/**
+ * Upload a file to Convex file storage via the agent component.
+ */
+export const uploadFile = action({
+  args: {
+    file: v.bytes(),
+    mimeType: v.string(),
+    filename: v.optional(v.string()),
+    sha256: v.optional(v.string()),
+  },
+  handler: async (ctx, { file, mimeType, filename, sha256 }) => {
+    const blob = new Blob([file], { type: mimeType });
+    const { file: stored } = await storeFile(
+      ctx,
+      components.agent,
+      blob,
+      filename,
+      sha256,
+    );
+    return stored;
+  },
+});
+
+/**
+ * Save a user message referencing a previously uploaded file and
+ * asynchronously stream the assistant response.
+ */
+export const streamFileMessageAsynchronously = mutation({
+  args: {
+    threadId: v.string(),
+    fileId: v.string(),
+    prompt: v.optional(v.string()),
+    model: v.optional(v.string()),
+  },
+  handler: async (ctx, { threadId, fileId, prompt, model }) => {
+    await requireUserId(ctx);
+    await requireOwnThread(ctx, threadId);
+    const { filePart, imagePart } = await getFile(ctx, components.agent, fileId);
+    const { messageId } = await agent.saveMessage(ctx, {
+      threadId,
+      message: {
+        role: "user",
+        content: [
+          imagePart ?? filePart,
+          ...(prompt ? [{ type: "text", text: prompt }] : []),
+        ],
+      },
+      metadata: { fileIds: [fileId] },
+      skipEmbeddings: true,
+    });
+
+    await ctx.scheduler.runAfter(0, internal.thread.maybeUpdateThreadTitle, {
+      threadId,
+    });
+
+    await ctx.scheduler.runAfter(0, internal.chat.streamMessage, {
+      threadId,
+      promptMessageId: messageId,
+      model,
+    });
+
+    return { threadId };
+  },
+});


### PR DESCRIPTION
## Summary
- implement backend file upload action and file message mutation
- allow chat view to attach files to messages on desktop and mobile

## Testing
- `pnpm lint`
- `pnpm check-types` *(fails: ENETUNREACH)*
- `pnpm dev` *(fails: command exited with error)*


------
https://chatgpt.com/codex/tasks/task_e_6853e9fbc7d883229476769783b95a71