### PR TITLE
Add file upload support to chat

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -17,8 +17,8 @@ import {
 import { api } from "@hyperwave/backend/convex/_generated/api";
 import type { ModelInfo } from "@hyperwave/backend/convex/models";
 import { useQuery } from "convex-helpers/react/cache";
-import { useMutation } from "convex/react";
-import { ArrowDown, ArrowUp, Check, Loader2 } from "lucide-react";
+import { useAction, useMutation } from "convex/react";
+import { ArrowDown, ArrowUp, Check, Loader2, Paperclip } from "lucide-react";
 import { useStickToBottom } from "use-stick-to-bottom";
 
 import { Message } from "./Message";
@@ -37,6 +37,7 @@ export function ChatView({
   onNewThread?: (id: string) => void;
 }) {
   const [prompt, setPrompt] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
   const modelsConfig = useQuery(api.models.listModels);
   const modelsLoaded = modelsConfig !== undefined;
   const [model, setModel] = useState<string>();
@@ -44,8 +45,14 @@ export function ChatView({
   const [modelFilter, setModelFilter] = useState("");
   const [activeModelIndex, setActiveModelIndex] = useState(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const handleFiles = (f: FileList | null) => {
+    if (!f) return;
+    setFiles(Array.from(f));
+  };
   useEffect(() => {
     if (modelsConfig && !model) {
       setModel(modelsConfig.defaultModel);
@@ -105,6 +112,7 @@ export function ChatView({
   );
 
   const createThread = useMutation(api.thread.createThread);
+  const uploadFile = useAction(api.files.uploadFile);
 
   const [isCreatingThread, setIsCreatingThread] = useState(false);
 
@@ -148,10 +156,27 @@ export function ChatView({
     e.preventDefault();
     const text = prompt.trim();
     if (!text || !modelsLoaded || !model) return;
+    const uploadedIds: string[] = [];
+    if (files.length > 0) {
+      for (const file of files) {
+        const buffer = await file.arrayBuffer();
+        const bytes = Array.from(new Int8Array(buffer));
+        const hashArray = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", buffer)));
+        const sha256 = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+        const { fileId } = await uploadFile({
+          bytes,
+          mimeType: file.type,
+          filename: file.name,
+          sha256,
+        });
+        uploadedIds.push(fileId);
+      }
+      setFiles([]);
+    }
     if (threadId) {
       setPrompt("");
       try {
-        const result = await sendMessage({ threadId, prompt: text, model });
+        const result = await sendMessage({ threadId, prompt: text, model, fileIds: uploadedIds });
         formRef.current?.reset();
         if (!threadId && onNewThread && result?.threadId) {
           onNewThread(result.threadId);
@@ -165,7 +190,7 @@ export function ChatView({
       try {
         const newThreadId = await createThread({});
         // Optimistically send the message but don't await it
-        void sendMessage({ threadId: newThreadId, prompt: text, model });
+        void sendMessage({ threadId: newThreadId, prompt: text, model, fileIds: uploadedIds });
         formRef.current?.reset();
         setPrompt("");
         if (onNewThread) {
@@ -245,7 +270,31 @@ export function ChatView({
                   isCreatingThread && "opacity-50",
                 )}
               />
-              <div className="flex items-end justify-between">
+              {files.length > 0 && (
+                <ul className="text-sm text-muted-foreground space-y-1">
+                  {files.map((f) => (
+                    <li key={f.name}>{f.name}</li>
+                  ))}
+                </ul>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                onChange={(e) => handleFiles(e.target.files)}
+                className="hidden"
+              />
+              <div className="flex items-end justify-between gap-2">
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isStreaming || isCreatingThread}
+                >
+                  <Paperclip className="h-4 w-4" />
+                  <span className="sr-only">Attach file</span>
+                </Button>
                 <Popover
                   open={modelMenuOpen}
                   onOpenChange={(open) => {

--- a/packages/backend/convex/chat.ts
+++ b/packages/backend/convex/chat.ts
@@ -1,9 +1,10 @@
-import { vStreamArgs } from "@convex-dev/agent";
+import { getFile, vStreamArgs } from "@convex-dev/agent";
+import type { FilePart, ImagePart, TextPart } from "ai";
 import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
 import { requireOwnThread, requireUserId } from "../utils/threadOwnership";
-import { internal } from "./_generated/api";
+import { components, internal } from "./_generated/api";
 import { internalAction, mutation, query } from "./_generated/server";
 import agent, { openrouter } from "./agent";
 import { allowedModels, defaultModel } from "./models";
@@ -23,8 +24,9 @@ export const streamMessageAsynchronously = mutation({
     prompt: v.string(), // User message
     threadId: v.string(),
     model: v.optional(v.string()),
+    fileIds: v.optional(v.array(v.string())),
   },
-  handler: async (ctx, { prompt, threadId, model }) => {
+  handler: async (ctx, { prompt, threadId, model, fileIds }) => {
     const userId = await requireUserId(ctx);
 
     if (!userId) {
@@ -33,10 +35,19 @@ export const streamMessageAsynchronously = mutation({
 
     await requireOwnThread(ctx, threadId);
 
-    // Save user message
+    const contentParts: Array<TextPart | ImagePart | FilePart> = [];
+    if (fileIds) {
+      for (const id of fileIds) {
+        const { filePart, imagePart } = await getFile(ctx, components.agent, id);
+        contentParts.push(imagePart ?? filePart);
+      }
+    }
+    contentParts.push({ type: "text", text: prompt });
+
     const { messageId } = await agent.saveMessage(ctx, {
       threadId,
-      prompt,
+      message: { role: "user", content: contentParts },
+      metadata: fileIds ? { fileIds } : undefined,
       // we're in a mutation, so skip embeddings for now. They'll be generated lazily when streaming text.
       skipEmbeddings: true,
     });

--- a/packages/backend/convex/files.ts
+++ b/packages/backend/convex/files.ts
@@ -6,13 +6,13 @@ import { action } from "./_generated/server";
 
 export const uploadFile = action({
   args: {
-    bytes: v.array(v.int8()),
+    data: v.bytes(),
     mimeType: v.string(),
     filename: v.optional(v.string()),
     sha256: v.optional(v.string()),
   },
-  handler: async (ctx, { bytes, mimeType, filename, sha256 }) => {
-    const blob = new Blob([new Uint8Array(bytes)], { type: mimeType });
+  handler: async (ctx, { data, mimeType, filename, sha256 }) => {
+    const blob = new Blob([data], { type: mimeType });
     const { file } = await storeFile(ctx, components.agent, blob, filename, sha256);
     return file;
   },

--- a/packages/backend/convex/files.ts
+++ b/packages/backend/convex/files.ts
@@ -1,0 +1,19 @@
+import { storeFile } from "@convex-dev/agent";
+import { v } from "convex/values";
+
+import { components } from "./_generated/api";
+import { action } from "./_generated/server";
+
+export const uploadFile = action({
+  args: {
+    bytes: v.array(v.int8()),
+    mimeType: v.string(),
+    filename: v.optional(v.string()),
+    sha256: v.optional(v.string()),
+  },
+  handler: async (ctx, { bytes, mimeType, filename, sha256 }) => {
+    const blob = new Blob([new Uint8Array(bytes)], { type: mimeType });
+    const { file } = await storeFile(ctx, components.agent, blob, filename, sha256);
+    return file;
+  },
+});


### PR DESCRIPTION
## Summary
- add `uploadFile` action to backend
- allow file attachments in chat messages
- extend chat mutation to handle uploaded files

## Testing
- `pnpm lint`
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6853e9fbc7d883229476769783b95a71