### PR TITLE
Fix link hover colors in light mode

### DIFF
--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -415,13 +415,13 @@ body {
     @apply rounded-md my-4;
   }
   .prose a {
-    @apply underline underline-offset-2 decoration-primary text-primary transition-colors;
+    @apply underline underline-offset-5 decoration-accent text-neptune-7 dark:text-neptune-6 transition-colors;
   }
   .prose a:hover {
-    color: var(--color-sol-8);
+    color: var(--color-neptune-9);
   }
   .dark .prose a:hover {
-    color: var(--primary-foreground);
+    color: var(--color-neptune-8);
   }
   .prose blockquote {
     @apply border-l-2 pl-4 italic text-muted-foreground my-4;

--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -418,7 +418,10 @@ body {
     @apply underline underline-offset-2 decoration-primary text-primary transition-colors;
   }
   .prose a:hover {
-    @apply text-primary-foreground;
+    color: var(--color-sol-8);
+  }
+  .dark .prose a:hover {
+    color: var(--primary-foreground);
   }
   .prose blockquote {
     @apply border-l-2 pl-4 italic text-muted-foreground my-4;


### PR DESCRIPTION
## Summary
- ensure markdown links remain visible on hover in light theme

## Testing
- `pnpm format`
- `pnpm check-types` *(fails: ENETUNREACH)*
- `pnpm format:check`
- `pnpm test` *(fails: ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_e_68542de3887c8322b0fd86f91a6b2c19