### PR TITLE
Persist chosen model across chats

### DIFF
--- a/apps/webapp/src/components/ChatView.tsx
+++ b/apps/webapp/src/components/ChatView.tsx
@@ -6,7 +6,10 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useLocalStorageString } from "@/hooks/use-local-storage";
+import {
+  useLocalStorageBoolean,
+  useLocalStorageString,
+} from "@/hooks/use-local-storage";
 import { cn } from "@/lib/utils";
 import type { MessageDoc } from "@convex-dev/agent";
 import {
@@ -90,7 +93,8 @@ export function ChatView({
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const [modelFilter, setModelFilter] = useState("");
   const [activeModelIndex, setActiveModelIndex] = useState(0);
-  const [webSearchEnabled, setWebSearchEnabled] = useState(false);
+  const [webSearchEnabled, setWebSearchEnabled] =
+    useLocalStorageBoolean("hyperwave-web-search", false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);

--- a/apps/webapp/src/hooks/use-local-storage.ts
+++ b/apps/webapp/src/hooks/use-local-storage.ts
@@ -1,0 +1,32 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+/**
+ * React hook to persist a string in localStorage.
+ *
+ * @param key - localStorage key
+ * @param defaultValue - value used if nothing is stored
+ * @returns stateful value and setter
+ */
+export function useLocalStorageString(
+  key: string,
+  defaultValue = "",
+): [string, Dispatch<SetStateAction<string>>] {
+  const [value, setValue] = useState(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored ?? defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/apps/webapp/src/hooks/use-local-storage.ts
+++ b/apps/webapp/src/hooks/use-local-storage.ts
@@ -30,3 +30,37 @@ export function useLocalStorageString(
 
   return [value, setValue];
 }
+
+/**
+ * React hook to persist a boolean flag in localStorage.
+ *
+ * Stored values are serialized as "true" or "false" strings.
+ *
+ * @param key - localStorage key
+ * @param defaultValue - value used if nothing is stored
+ * @returns stateful value and setter
+ */
+export function useLocalStorageBoolean(
+  key: string,
+  defaultValue = false,
+): [boolean, Dispatch<SetStateAction<boolean>>] {
+  const [value, setValue] = useState<boolean>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) return defaultValue;
+      return stored === "true";
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, value ? "true" : "false");
+    } catch {
+      // Ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}


### PR DESCRIPTION
## Summary
- store selected model ID in localStorage with new `useLocalStorageString` hook
- preserve model when switching pages in `ChatView`
- focus chat input when navigating to a thread
- gracefully fallback to the server default when the stored model isn't available

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH)*
- `pnpm dev:webapp` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68544f9831b8832296fd99fc215a84c9