### PR TITLE
Display uploaded images in chat

### DIFF
--- a/apps/webapp/src/components/Message.tsx
+++ b/apps/webapp/src/components/Message.tsx
@@ -59,6 +59,18 @@ function renderPart(part: UIMessage["parts"][number]): React.ReactNode {
           </div>
         </div>
       );
+    case "file": {
+      const url =
+        part.data.startsWith("http://") ||
+        part.data.startsWith("https://") ||
+        part.data.startsWith("blob:") ||
+        part.data.startsWith("data:")
+          ? part.data
+          : `data:${part.mimeType};base64,${part.data}`;
+      return part.mimeType.startsWith("image/") ? (
+        <img src={url} alt="uploaded image" className="max-w-full h-auto rounded" />
+      ) : null;
+    }
     default:
       return null;
   }

--- a/apps/webapp/src/components/Message.tsx
+++ b/apps/webapp/src/components/Message.tsx
@@ -68,7 +68,7 @@ function renderPart(part: UIMessage["parts"][number]): React.ReactNode {
           ? part.data
           : `data:${part.mimeType};base64,${part.data}`;
       return part.mimeType.startsWith("image/") ? (
-        <img src={url} alt="uploaded image" className="max-w-full h-auto rounded" />
+        <img src={url} alt="uploaded image" className="max-w-full h-auto p-6 rounded" />
       ) : null;
     }
     default:


### PR DESCRIPTION
## Summary
- show image files for any `file` part in chat messages

## Testing
- `pnpm test` *(fails: connect ENETUNREACH)*
- `pnpm dev` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68545ac55308832285aef00cd71f5e24